### PR TITLE
[fix] more unique file name

### DIFF
--- a/server/services/import/utils/file.js
+++ b/server/services/import/utils/file.js
@@ -178,7 +178,7 @@ const getFileTypeChecker = (type) => {
 const getFileDataFromRawUrl = (rawUrl) => {
   const parsedUrl = new URL(decodeURIComponent(rawUrl));
 
-  const fileName = parsedUrl.pathname.split('/').pop().toLowerCase();
+  const fileName = parsedUrl.pathname.toLowerCase().replaceAll('/', '-');
 
   return {
     fileName: fileName,

--- a/server/services/import/utils/file.js
+++ b/server/services/import/utils/file.js
@@ -178,7 +178,7 @@ const getFileTypeChecker = (type) => {
 const getFileDataFromRawUrl = (rawUrl) => {
   const parsedUrl = new URL(decodeURIComponent(rawUrl));
 
-  const fileName = parsedUrl.pathname.toLowerCase().replaceAll('/', '-');
+  const fileName = parsedUrl.pathname.toLowerCase().replace(/\//g, '-');
 
   return {
     fileName: fileName,


### PR DESCRIPTION
Many files with frequently used names like 1.jpg are ignored by the plugin (it uses a different file with the same name), so I often get wrong files attached to my imported entries.

This is my fix for that.