### PR TITLE
Fetch file from url should encode special chars

### DIFF
--- a/server/services/import/utils/file.js
+++ b/server/services/import/utils/file.js
@@ -113,7 +113,7 @@ const importFile = async ({ url, name, alternativeText, caption }, user) => {
 
 const fetchFile = (url) => {
   return new Promise((resolve, reject) => {
-    request({ url, method: 'GET', encoding: null }, async (err, res, body) => {
+    request({ url: encodeURI(url), method: 'GET', encoding: null }, async (err, res, body) => {
       if (err) {
         reject(err);
         return;


### PR DESCRIPTION
I am getting an error while fetching the file. The url exists, but when fetching via node it's necessary to `encodeURI` the url to encode special characters.

Example:
```js
encodeURI('https://www.anteprojectos.com.pt/wp-content/uploads/2010/03/Hospital-Central-da-Madeira-peça-desenhada-corte.jpg')
// 'https://www.anteprojectos.com.pt/wp-content/uploads/2010/03/Hospital-Central-da-Madeira-pe%25C3%25A7a-desenhada-corte.jpg'
```