### PR TITLE
A promise should reject the error, not throw it

### DIFF
--- a/server/services/import/utils/file.js
+++ b/server/services/import/utils/file.js
@@ -120,7 +120,7 @@ const fetchFile = (url) => {
       }
 
       if (res.statusCode < 200 || 300 <= res.statusCode) {
-        throw new Error(`Tried to fetch file from url ${url} but failed with status code ${res.statusCode}`);
+        reject(new Error(`Tried to fetch file from url ${url} but failed with status code ${res.statusCode}`));
       }
 
       const type = res.headers['content-type'].split(';').shift();


### PR DESCRIPTION
If you throw it instead of rejecting it, it will stop all the process of importing. So, for example, if I am fetching 1000 files and my 6th file receives a 404, I can't go through it.