### PR TITLE
[feat] ignore extension check

### DIFF
--- a/server/config/index.js
+++ b/server/config/index.js
@@ -6,6 +6,10 @@ module.exports = {
      * Public hostname of the server.
      */
     serverPublicHostname: '',
+    /**
+     * Ignore extension check (trust imported JSON/CSV) or not.
+     */
+    ignoreExtensionCheck: false,
   },
   validator: ({ serverPublicHostname } = {}) => {
     if (typeof serverPublicHostname !== 'string') {

--- a/server/services/import/utils/file.js
+++ b/server/services/import/utils/file.js
@@ -7,6 +7,7 @@ const path = require('path');
 const request = require('request');
 
 const { isObjectSafe } = require('../../../../libs/objects');
+const { getConfig } = require('../../../utils/getConfig');
 
 /**
  * Find or import a file.
@@ -191,6 +192,7 @@ const isValidFileUrl = (url, allowedFileTypes) => {
 };
 
 const isExtensionAllowed = (ext, allowedFileTypes) => {
+  if (getConfig('ignoreExtensionCheck')) return true;
   const checkers = allowedFileTypes.map(getFileTypeChecker);
   return checkers.some((checker) => checker(ext));
 };


### PR DESCRIPTION
I faced a situation where I had to import 100% correct data from contentful, but some media links were like images.ctfassets.net/a6f2hu560hd9/5BKzFyXMhEDZjuTmbnMAMa/2e2f45cd07ef92dc1fd4b6112bfdedf4/30-1024x683.jpg_w_2540_h_1300_fm_jpg_fl_progressive or with no extension at all. So I've added this option.