### PR TITLE
Fixed Media Components causing Imports to Partially Fail when Not Found

### DIFF
--- a/src/server/services/import/import-v2.ts
+++ b/src/server/services/import/import-v2.ts
@@ -290,6 +290,17 @@ function setComponents(
       }
     } else if (isDynamicZoneAttribute(attribute)) {
       store[attributeName] = (attributeValue as FileEntryDynamicZone[]).map(({ __component, id }) => getComponentData(__component, `${id}`, { fileIdToDbId, componentsDataStore }));
+    } else if (isMediaAttribute(attribute)) {
+      if (attribute.multiple) {
+        store[attributeName] = (attributeValue as (number | string)[]).map((id) => fileIdToDbId.getMapping('plugin::upload.file', id)).filter((id) => id !== undefined);
+      } else {
+        store[attributeName] = fileIdToDbId.getMapping('plugin::upload.file', attributeValue as number | string);
+        // if the media wasn't found remove it from the update
+        if (!store[attributeName]) {
+          delete fileEntry[attributeName];
+          delete store[attributeName];
+        }
+      }
     }
   }
 
@@ -331,9 +342,14 @@ function getComponentData(
       store[attributeName] = (attributeValue as FileEntryDynamicZone[]).map(({ __component, id }) => getComponentData(__component, `${id}`, { fileIdToDbId, componentsDataStore }));
     } else if (isMediaAttribute(attribute)) {
       if (attribute.multiple) {
-        store[attributeName] = (attributeValue as (number | string)[]).map((id) => fileIdToDbId.getMapping('plugin::upload.file', id));
+        store[attributeName] = (attributeValue as (number | string)[]).map((id) => fileIdToDbId.getMapping('plugin::upload.file', id)).filter((id) => id !== undefined);
       } else {
         store[attributeName] = fileIdToDbId.getMapping('plugin::upload.file', attributeValue as number | string);
+        // if the media wasn't found remove it from the update
+        if (!store[attributeName]) {
+          delete fileEntry[attributeName];
+          delete store[attributeName];
+        }
       }
     } else if (isRelationAttribute(attribute)) {
       if (attribute.relation.endsWith('Many')) {


### PR DESCRIPTION
This fixes errors related to media components that cause imports to partially fail by implementing the following workarounds:
- If a field contains a single media element, and that media element is not found, the field is removed from the import.
- If a field can contain multiple media components, all media elements that are not found in the field are removed from the import.

Also, when a matching media element was found on the target DB, their ID's were not being mapped to on another before create/update calls. This fixes that issue by updating the ID to the mapped ID in `setComponents` .