### PR TITLE
feat(fileIdToDbId): add relation and media support for ID mapping

### DIFF
--- a/src/server/services/import/import-v2.ts
+++ b/src/server/services/import/import-v2.ts
@@ -290,6 +290,25 @@ function setComponents(
       }
     } else if (isDynamicZoneAttribute(attribute)) {
       store[attributeName] = (attributeValue as FileEntryDynamicZone[]).map(({ __component, id }) => getComponentData(__component, `${id}`, { fileIdToDbId, componentsDataStore }));
+    } else if (isRelationAttribute(attribute)) {
+      switch (attribute.relation) {
+        case 'oneToMany':
+        case 'manyToMany':
+          store[attributeName] = (attributeValue as (number | string)[]).map((id) => fileIdToDbId.getMapping(attribute.target, id));
+          break;
+        case 'oneToOne':
+        case 'manyToOne':
+          store[attributeName] = fileIdToDbId.getMapping(attribute.target, `${attributeValue as number | string}`);
+          break;
+      }
+    }
+    else if (isMediaAttribute(attribute)) {
+      if (attribute.multiple) {
+        store[attributeName] = (attributeValue as number[] | string[]).map((id) => fileIdToDbId.getMapping('plugin::upload.file', id));
+      }
+      else {
+        store[attributeName] = fileIdToDbId.getMapping('plugin::upload.file', `${attributeValue as number | string}`);
+      }
     }
   }
 

--- a/tests/helpers/test-app/src/api/with-relation/content-types/relation-c/schema.json
+++ b/tests/helpers/test-app/src/api/with-relation/content-types/relation-c/schema.json
@@ -1,0 +1,44 @@
+{
+  "kind": "collectionType",
+  "collectionName": "relation_c",
+  "info": {
+    "singularName": "relation-c",
+    "pluralName": "relations-c",
+    "displayName": "RelationC"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {
+    "import-export-entries": {
+      "idField": "name"
+    }
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "unique": true,
+      "required": true
+    },
+    "relationOneToOne": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::with-relation.relation-d"
+    },
+    "relationOneToMany": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::with-relation.relation-d"
+    },
+    "relationManyToOne": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::with-relation.relation-d"
+    },
+    "relationManyToMany": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::with-relation.relation-d"
+    }
+  }
+}

--- a/tests/helpers/test-app/src/api/with-relation/content-types/relation-d/schema.json
+++ b/tests/helpers/test-app/src/api/with-relation/content-types/relation-d/schema.json
@@ -1,0 +1,44 @@
+{
+  "kind": "collectionType",
+  "collectionName": "relation_d",
+  "info": {
+    "singularName": "relation-d",
+    "pluralName": "relations-d",
+    "displayName": "RelationD"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {
+    "import-export-entries": {
+      "idField": "name"
+    }
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "unique": true,
+      "required": true
+    },
+    "relationOneToOne": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::with-relation.relation-c"
+    },
+    "relationOneToMany": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::with-relation.relation-c"
+    },
+    "relationManyToOne": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::with-relation.relation-c"
+    },
+    "relationManyToMany": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::with-relation.relation-c"
+    }
+  }
+}

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -10,6 +10,8 @@ const SLUGS = {
   COMPONENT_COMPONENT: 'component.component',
   RELATION_A: 'api::with-relation.relation-a',
   RELATION_B: 'api::with-relation.relation-b',
+  RELATION_C: 'api::with-relation.relation-c',
+  RELATION_D: 'api::with-relation.relation-d',
   SINGLE_TYPE: 'api::single-type.single-type',
   SINGLE_TYPE_SIMPLE: 'api::single-type.single-type-simple',
 };
@@ -47,6 +49,18 @@ const generateData = (slug, customData = {}) => {
     };
   }
   if (slug === SLUGS.RELATION_B) {
+    return {
+      name: faker.helpers.unique(faker.word.noun),
+      ...customData,
+    };
+  }
+  if (slug === SLUGS.RELATION_C) {
+    return {
+      name: faker.helpers.unique(faker.word.noun),
+      ...customData,
+    };
+  }
+  if (slug === SLUGS.RELATION_D) {
     return {
       name: faker.helpers.unique(faker.word.noun),
       ...customData,


### PR DESCRIPTION
Related to: https://github.com/Baboo7/strapi-plugin-import-export-entries/issues/151
User story: 

As import/export script
taken `fieldId` is defined  in Strapi pluginOptions
taken all `Id` fields are removed from ExportDataFile
I am importing JSON-V2 data structure to strapi with goal to allow different IDs on Source and Destination Strapi instance, but keeping references to components and  based on fileIDs

This PR uses the existing `fileIdToDbId` mapping and applies it to relations and media which were ignored until now. 

Tested (all passing) 
