### PR TITLE
Fix: recognize latest strapi paths

### DIFF
--- a/admin/src/hooks/useSlug.js
+++ b/admin/src/hooks/useSlug.js
@@ -7,7 +7,7 @@ export const useSlug = () => {
   const { pathname } = useLocation();
 
   const slug = useMemo(() => {
-    const matches = pathname.match(/content-manager\/(collectionType|singleType)\/([a-zA-Z0-9\-:_.]*)/);
+    const matches = pathname.match(/content-manager\/(collectionType|singleType|collection-types|single-types)\/([a-zA-Z0-9\-:_.]*)/);
     return matches?.[2] ? matches[2] : SLUG_WHOLE_DB;
   }, [pathname]);
 


### PR DESCRIPTION
Hi there,

this PR should fix #166

latest version of Strapi uses different paths: `/admin/content-manager/collection-types` and `/admin/content-manager/content-manager/single-types`

this PR extends the useSlug hook with backwards compatibility (if you want to run this version in an older version of Strapi)