### PR TITLE
Fix: export plugins ContentTypes when exporting whole database

### DIFF
--- a/src/server/controllers/admin/export-controller/export-controller.js
+++ b/src/server/controllers/admin/export-controller/export-controller.js
@@ -25,10 +25,10 @@ const exportData = async (ctx) => {
 };
 
 const hasPermissions = (ctx) => {
-  let { slug } = ctx.request.body;
+  let { slug, exportPluginsContentTypes } = ctx.request.body;
   const { userAbility } = ctx.state;
 
-  const slugs = slug === CustomSlugs.WHOLE_DB ? getAllSlugs() : [slug];
+  const slugs = slug === CustomSlugs.WHOLE_DB ? getAllSlugs({ includePluginsContentTypes: exportPluginsContentTypes }) : [slug];
 
   const allowedSlugs = slugs.filter((slug) => {
     const permissionChecker = strapi.plugin('content-manager').service('permission-checker').create({ userAbility, model: slug });


### PR DESCRIPTION
Hi there,

currently if I choose `Export plugins content types` when exporting the whole database, it does not work.

![image](https://github.com/Baboo7/strapi-plugin-import-export-entries/assets/4119960/ac5c761b-cd75-418b-99e1-2bfb75452b40)

the reason is that the prop `exportPluginsContentTypes` is not passed into the `getAllSlugs` function.
this PR should fix this.