### PR TITLE
Fix: skip PolymorphicRelationsType during export

### DIFF
--- a/src/server/services/export/export-v2.ts
+++ b/src/server/services/export/export-v2.ts
@@ -25,7 +25,7 @@ import {
   isComponentAttribute,
   isDynamicZoneAttribute,
   isMediaAttribute,
-  isRelationAttribute,
+  isBasicRelationsTypeAttribute,
   getModel,
   deleteEntryProp,
   setEntryProp,
@@ -164,7 +164,7 @@ async function findEntriesForHierarchy(
         }));
       } else if (isMediaAttribute(propAttribute)) {
         return flattenEntryCommon(propEntries);
-      } else if (isRelationAttribute(propAttribute)) {
+      } else if (isBasicRelationsTypeAttribute(propAttribute)) {
         return flattenEntryCommon(propEntries);
       }
       return propEntries;
@@ -373,7 +373,7 @@ function getPopulateFromSchema(slug: string, deepness = 5): Populate | true | un
         return compPopulate === true ? zonePopulate : merge(zonePopulate, compPopulate);
       }, {});
       populate[attributeName] = isEmpty(dynamicPopulate) ? true : dynamicPopulate;
-    } else if (isRelationAttribute(attribute)) {
+    } else if (isBasicRelationsTypeAttribute(attribute)) {
       const relationPopulate = getPopulateFromSchema(attribute.target, deepness - 1);
       if (relationPopulate) {
         populate[attributeName] = relationPopulate;
@@ -413,7 +413,7 @@ function buildSlugHierarchy(slug: SchemaUID, deepness = 5): Hierarchy {
       hierarchy[attributeName] = buildSlugHierarchy(attribute.component, deepness - 1);
     } else if (isDynamicZoneAttribute(attribute)) {
       hierarchy[attributeName] = Object.fromEntries(attribute.components.map((componentSlug) => [componentSlug, buildSlugHierarchy(componentSlug, deepness - 1)]));
-    } else if (isRelationAttribute(attribute)) {
+    } else if (isBasicRelationsTypeAttribute(attribute)) {
       const relationHierarchy = buildSlugHierarchy(attribute.target, deepness - 1);
       if (relationHierarchy) {
         hierarchy[attributeName] = relationHierarchy;

--- a/src/server/services/import/import-v2.ts
+++ b/src/server/services/import/import-v2.ts
@@ -5,7 +5,7 @@ import pick from 'lodash/pick';
 import castArray from 'lodash/castArray';
 import { extract, toArray } from '../../../libs/arrays';
 import { ObjectBuilder } from '../../../libs/objects';
-import { getModel, getModelAttributes, isComponentAttribute, isDynamicZoneAttribute, isMediaAttribute, isRelationAttribute } from '../../utils/models';
+import { getModel, getModelAttributes, isComponentAttribute, isDynamicZoneAttribute, isMediaAttribute, isBasicRelationsTypeAttribute } from '../../utils/models';
 import { Entry, EntryId, Schema, SchemaUID, User } from '../../types';
 import { head, toPairs } from 'lodash';
 import { FileEntry, FileEntryDynamicZone, FileId } from './types';
@@ -359,7 +359,7 @@ function getComponentData(
       } else {
         store[attributeName] = fileIdToDbId.getMapping('plugin::upload.file', attributeValue as number | string);
       }
-    } else if (isRelationAttribute(attribute)) {
+    } else if (isBasicRelationsTypeAttribute(attribute)) {
       if (attribute.relation.endsWith('Many')) {
         store[attributeName] = (attributeValue as (number | string)[]).map((id) => fileIdToDbId.getMapping(attribute.target, id));
       } else {

--- a/src/server/utils/models.ts
+++ b/src/server/utils/models.ts
@@ -1,3 +1,4 @@
+import { BasicRelationsType } from '@strapi/strapi';
 import { toArray } from '../../libs/arrays';
 import { Attribute, AttributeType, ComponentAttribute, DynamicZoneAttribute, Entry, MediaAttribute, RelationAttribute, Schema, SchemaUID } from '../types';
 
@@ -9,7 +10,7 @@ export {
   isComponentAttribute,
   isDynamicZoneAttribute,
   isMediaAttribute,
-  isRelationAttribute,
+  isBasicRelationsTypeAttribute,
   getEntryProp,
   setEntryProp,
   deleteEntryProp,
@@ -23,7 +24,7 @@ module.exports = {
   isComponentAttribute,
   isDynamicZoneAttribute,
   isMediaAttribute,
-  isRelationAttribute,
+  isBasicRelationsTypeAttribute,
   getEntryProp,
   setEntryProp,
   deleteEntryProp,
@@ -101,8 +102,10 @@ function isMediaAttribute(attribute: any): attribute is MediaAttribute {
   return (attribute as { type: AttributeType }).type === 'media';
 }
 
-function isRelationAttribute(attribute: any): attribute is RelationAttribute {
-  return (attribute as { type: AttributeType }).type === 'relation';
+function isBasicRelationsTypeAttribute(attribute: any): attribute is RelationAttribute {
+  const relation = (attribute as { relation: BasicRelationsType }).relation;
+
+  return (attribute as { type: AttributeType }).type === 'relation' && (relation === 'oneToOne' || relation === 'oneToMany' || relation === 'manyToOne' || relation === 'manyToMany');
 }
 
 function getEntryProp(entry: Entry, prop: string): any {


### PR DESCRIPTION
Hi there,

This one a bit more complicated
During a whole database export I run into the following issue when also exporting plugin content-types:
- Strapi released a future plugin not long ago called: Content Releases (https://docs.strapi.io/user-docs/releases/introduction) that is enabled by default nowadays
- this plugin uses a relation of type: `PolymorphicRelationsType` (see: https://github.com/strapi/strapi/blob/develop/packages/core/content-releases/server/src/content-types/release-action/schema.ts#L29)
- during the export `strapi-plugin-import-export-entries` fails on this because it can only handle `BasicRelationsType`s

in this PR, I added logic to skip  `PolymorphicRelationsType` and only handle `BasicRelationsType` relations.

questions:
- I'm not sure if this is the correct thing to do, I know too little about how the PolymorphicRelationsType should be handled.
- I looked into disabling the Content Releases plugin, but I couldn't find anything on this.

Gr,

Ronald van der Kooij