### PR TITLE
[HOTFIX] Update pathname to work on newer strapi versions, while maintaining compatibility with older versions

### DIFF
--- a/admin/src/hooks/useSlug.js
+++ b/admin/src/hooks/useSlug.js
@@ -1,13 +1,18 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useAppInfo } from '@strapi/helper-plugin';
+import semver from 'semver';
 
 const SLUG_WHOLE_DB = 'custom:db';
 
 export const useSlug = () => {
   const { pathname } = useLocation();
+  const { strapiVersion } = useAppInfo();
 
   const slug = useMemo(() => {
-    const matches = pathname.match(/content-manager\/(collectionType|singleType)\/([a-zA-Z0-9\-:_.]*)/);
+    const contentTypeTypography = semver.lt(strapiVersion, '4.17.0') ?  "collectionType|singleType" : "collection-types|single-types";
+
+    const matches = pathname.match(new RegExp(`content-manager\/(${contentTypeTypography})\/([a-zA-Z0-9\-:_.]*)`));
     return matches?.[2] ? matches[2] : SLUG_WHOLE_DB;
   }, [pathname]);
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "monaco-editor": "0.33.0",
     "monaco-editor-webpack-plugin": "7.0.1",
     "node-fetch": "2.6.9",
-    "react-singleton-hook": "3.3.0"
+    "react-singleton-hook": "3.3.0",
+    "semver": "7.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.5",


### PR DESCRIPTION
Use strapi version to check if use `collection-types|single-types` or `collectionType|singleType` ir pathname regex match.


Not sure which version it was add! :(